### PR TITLE
Add bower.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ If you're using GeoJSON boundaries, there are no dependencies.  If you're using 
 <script src="wherewolf.js"></script>
 ```
 
-Wherewolf is also available as a [Node module](https://www.npmjs.org/package/wherewolf), installed via npm.
+Wherewolf is available as a [Node module](https://www.npmjs.org/package/wherewolf), installed via npm.
 
 ```
 npm install wherewolf
+```
+
+Wherewolf can also be installed with [Bower](http://bower.io).
+
+```
+bower install --save wherewolf
 ```
 
 # API
@@ -286,7 +292,7 @@ In this way, you load very little data up front, but the downside is you introdu
 * This may not work for certain special cases of a point that lies right on the antimeridian being checked against a feature that crosses the antimeridian. It's unclear whether any scenario on the actual earth can cause this problem.  The Aleutian Islands work fine.
 * Wherewolf will only match against GeoJSON `Polygons`,`MultiPolygons`,and `Points`.  It will not work with a feature that's a `LineString`.
 * If your geographic data file is invalid, you may get unpredictable results.  Wherewolf assumes that your polygons do not self-intersect or overlap.  If a point matches more than one feature in one layer, Wherewolf will return the first match it finds.
-* Your results will only be as accurate as your data is precise.  If the boundaries you're using are highly simplified, you may get inaccurate results for points near a border. 
+* Your results will only be as accurate as your data is precise.  If the boundaries you're using are highly simplified, you may get inaccurate results for points near a border.
 
 # Credits/License
 

--- a/bower.json
+++ b/bower.json
@@ -16,5 +16,8 @@
     "geojson",
     "point-in-polygon",
     "boundary"
-  ]
+  ],
+  "dependencies": {
+    "topojson": "~1.6.18"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "wherewolf",
+  "version": "1.0.2",
+  "main": "wherewolf.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "examples",
+    "junk",
+    "test",
+    "*.png",
+    "package.json"
+  ],
+  "keywords": [
+    "javascript",
+    "geojson",
+    "point-in-polygon",
+    "boundary"
+  ]
+}


### PR DESCRIPTION
Would y'all be up for adding the library to [Bower](http://bower.io)?

I have a basic `bower.json` set up. Could use some further tweaking/additions as y'all see fit! We use Bower for much of our dependency management with JavaScript libraries via [wiredep](https://github.com/taptapship/wiredep) at the Texas Tribune, so it'd be nice to add `wherewolf` to the pile of stuff that supports it.

I *did not* [register it](http://bower.io/docs/creating-packages/#register).