### PR TITLE
Use RBush spatial index if module is loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/veltman/wherewolf",
   "dependencies": {
+    "rbush": "^2.0.1",
     "topojson": "~1.6.18"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,18 @@ fs.readFile(path.join(__dirname,"../examples/nyc/districts.json"), "utf8", funct
   assert.deepEqual(ww.find(point,{layer: "Borough (NYC)"}).name,"Manhattan", ["layer option search error"]);
   assert.deepEqual(ww.find(point,{wholeFeature: true})["Neighborhood (NYC)"].type, "Feature", ["whole feature search error"]);
   assert.deepEqual(ww.find(point,{wholeFeature: true, layer: "Borough (NYC)"}).type, "Feature", ["whole feature + layer search error"]);
+
+  // repeat with indexing enabled
+    ww = Wherewolf({index: true});
+    ww.addAll(data);
+
+  assert.deepEqual(ww.find({lat:point[1], lng:point[0]})["Borough (NYC)"].name,"Manhattan", ["find dict point error"]);
+  assert.deepEqual(ww.find(point)["Borough (NYC)"].name,"Manhattan", ["find array point error"]);
+
+  //find options
+  assert.deepEqual(ww.find(point,{layer: "Borough (NYC)"}).name,"Manhattan", ["layer option search error"]);
+  assert.deepEqual(ww.find(point,{wholeFeature: true})["Neighborhood (NYC)"].type, "Feature", ["whole feature search error"]);
+  assert.deepEqual(ww.find(point,{wholeFeature: true, layer: "Borough (NYC)"}).type, "Feature", ["whole feature + layer search error"]);
 });
 
 //check geojson add

--- a/wherewolf.js
+++ b/wherewolf.js
@@ -26,20 +26,25 @@
   }
 
   //Factory function
-  var ww = function() {
+  var ww = function(options) {
 
-    return new Wherewolf();
+    return new Wherewolf(options);
 
   };
 
   //Basic class
   //Start with empty layers
-  var Wherewolf = function() {
+  var Wherewolf = function(options) {
+    //Defaults
+    options = options || {};
 
     this.layers = {};
     
     //Object for storing layer indices
-    if (rb) {
+    if (options.index) {
+      if (!rb) {
+        throw new Error("You must include the RBush library (https://github.com/mourner/rbush) to enable indexing.");
+      }
       this.indices = {};
     }
 
@@ -99,8 +104,8 @@
     this.layers[name] = features;
     
     //Add to index
-    if (rb) {
-      this.indices[name] = rb(9, ['.bbox[0][0]', '.bbox[0][1]', '.bbox[1][0]', '.bbox[1][1]']);
+    if (this.indices) {
+      this.indices[name] = rb(16, ['.bbox[0][0]', '.bbox[0][1]', '.bbox[1][0]', '.bbox[1][1]']);
       this.indices[name].load(features);
     }
 
@@ -147,7 +152,7 @@
     if (layerName in this.layers) {
       delete this.layers[layerName];
     }
-    if (rb && layerName in this.indices) {
+    if (this.indices && layerName in this.indices) {
       delete this.indices[layerName];
     }
 
@@ -193,7 +198,7 @@
     if (options.layer) {
       
       //Has index?
-      if (rb && options.layer in this.indices) {
+      if (this.indices && options.layer in this.indices) {
         return _findLayer(point,_queryIndex(point,this.indices[options.layer]),options);
       }
 
@@ -210,7 +215,7 @@
       results = {};
 
       for (var key in this.layers) {
-        if (rb && key in this.indices) {
+        if (this.indices && key in this.indices) {
           results[key] = _findLayer(point,_queryIndex(point,this.indices[key]),options);
         } else {
           results[key] = _findLayer(point,this.layers[key],options);


### PR DESCRIPTION
I have been using the Werewolf package for a project, and noticed that there are some performance bottlenecks when doing a large number of lookups. Specifically, I was doing about 4,000 lookups across all counties in the US (~3,000 polygons).

In order to improve performance, I integrated a spatial index into Wherewolf. With the help of a spatial index, rather than searching through all features in the layer, Wherewolf can query for those features where the bounding box intersects with the point (the spatial index uses a tree structure to quickly identify such intersections) and only evaluate whether the query point is within the shorter list of features. (There is a [good primer on spatial indices](https://medium.com/@agafonkin/a-dive-into-spatial-search-algorithms-ebd0c5e39d2a) that inspired this change.)

I wanted to potentially contribute this change back to the community as I think it might be more widely useful. Specifically, these changes do the following:

If the [rbush](https://github.com/mourner/rbush) module is installed or loaded before Wherewolf, it will use rbush to make a spatial index of each layer and more quickly search the layer (allowing it to only search those bounding boxes that intersect with the search point).

If rbush is not available, it will continue to perform as is.

For my example, this produced substantial improvements in querying and a slight performance hit during initialization (tests run in Safari Technology Preview):

|Step|w/o rbush|w/ rbush|
|----|---:|---:|
|Initialization (loading features)|30ms|61ms|
|Running 3,000 lookups|1,016ms|67ms|

Notes:

* All tests continue to pass. 
* There may be issues associated with the antimeridian, but I am not sure.
* I added rbush to the dependencies, but that may not make sense since it is optional.